### PR TITLE
get_attachment doesn't retrieve the document from the good revision

### DIFF
--- a/couchdb2.py
+++ b/couchdb2.py
@@ -699,7 +699,7 @@ class Database(object):
     def get_attachment(self, doc, filename):
         "Return a file-like object containing the content of the attachment."
         response = self.server._GET(self.name, doc["_id"], filename,
-                                    headers={"If-Match": doc["_rev"]})
+                                    params={"rev": doc["_rev"]})
         return io.BytesIO(response.content)
 
     def put_attachment(self, doc, content, filename=None, content_type=None):


### PR DESCRIPTION
Seems there is a bug with If-Match header for get_attachment, works with rev parameter.